### PR TITLE
pip install fixes

### DIFF
--- a/src/Dockerfile.azfinsim
+++ b/src/Dockerfile.azfinsim
@@ -9,6 +9,7 @@ RUN apt-get clean && rm -rf /var/lib/apt-lists/*
 RUN mkdir /azfinsim
 COPY requirements.txt /azfinsim
 WORKDIR /azfinsim
+RUN python3 -m pip install -U pip
 RUN pip3 install -r requirements.txt
 COPY azfinsim.py /azfinsim/
 COPY utils.py /azfinsim/

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,10 +1,10 @@
 setuptools
 wheel
 psutil
-azure.batch
-azure.identity
-azure.common
-azure.keyvault
+azure-batch
+azure-identity
+azure-common
+azure-keyvault
 applicationinsights
 pandas
 numpy


### PR DESCRIPTION
Added fixes encountered with pip install on ubuntu18.

requirements.txt - fixed referenes to azure-* (was azure.*)
Dockerfile.azfinsim - added pip update to address issue installing one of the python modules (cryptography.py)